### PR TITLE
chore: release v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/prmadev/leafslug/compare/v0.1.3...v0.1.4) - 2023-08-05
+
+### Added
+- add lesly
+
+### Other
+- fix broken workflow
+- add more secret to the secrets
+
 ## [0.1.3](https://github.com/prmadev/leafslug/compare/v0.1.2...v0.1.3) - 2023-08-05
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "leafslug"
-version = "0.1.3"
+version = "0.1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "leafslug"
 description = "Leafslug is an application to help happy hippies find food."
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 authors = ["Perma <prma.dev@protonmail.com>", "Pegah <pegah760.pk@gmail.com>"]
 homepage = "https://github.com/prmadev/leafslug"


### PR DESCRIPTION
## 🤖 New release
* `leafslug`: 0.1.3 -> 0.1.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.4](https://github.com/prmadev/leafslug/compare/v0.1.3...v0.1.4) - 2023-08-05

### Added
- add lesly

### Other
- fix broken workflow
- add more secret to the secrets
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).