### PR TITLE
chore: release v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.5](https://github.com/prmadev/leafslug/compare/v0.1.4...v0.1.5) - 2023-08-05
+
+### Other
+- fix broken workflow
+- fix broken workflow
+- fix broken workflow
+- fix broken workflow

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "leafslug"
-version = "0.1.4"
+version = "0.1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "leafslug"
 description = "Leafslug is an application to help happy hippies find food."
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 authors = ["Perma <prma.dev@protonmail.com>", "Pegah <pegah760.pk@gmail.com>"]
 homepage = "https://github.com/prmadev/leafslug"


### PR DESCRIPTION
## 🤖 New release
* `leafslug`: 0.1.4 -> 0.1.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.5](https://github.com/prmadev/leafslug/compare/v0.1.4...v0.1.5) - 2023-08-05

### Other
- fix broken workflow
- fix broken workflow
- fix broken workflow
- fix broken workflow
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).