### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/prmadev/leafslug/compare/v0.1.5...v0.2.0) - 2023-09-04
+
+### Added
+- add simple login api
+- update the model for use with a product
+- add figment configuration
+- add quick_dev
+- add axum infra
+- add some crates
+- remove cargo migrate
+- add .sqlx dir
+- add crud for ingredients
+
+### Fixed
+- returning the result directly in the quick_dev
+- fix linting issues here and there
+- comment the test out
+
+### Other
+- better test management
+- comment out axum for now
+- *(deps)* bump rustls-webpki from 0.101.3 to 0.101.4
+- add comment explaining lesly
+- ignore clippy::multiple_crate_versions
+- remove link checker
+
 ## [0.1.5](https://github.com/prmadev/leafslug/compare/v0.1.4...v0.1.5) - 2023-08-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "leafslug"
-version = "0.1.5"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "leafslug"
 description = "Leafslug is an application to help happy hippies find food."
-version = "0.1.5"
+version = "0.2.0"
 edition = "2021"
 authors = ["Perma <prma.dev@protonmail.com>", "Pegah <pegah760.pk@gmail.com>"]
 homepage = "https://github.com/prmadev/leafslug"


### PR DESCRIPTION
## 🤖 New release
* `leafslug`: 0.1.5 -> 0.2.0 (⚠️ API breaking changes)

### ⚠️ `leafslug` breaking changes

```
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-check/tree/v0.22.1/src/lints/enum_missing.ron

Failed in:
  enum leafslug::domain::restrictions::Restriction, previously in file /tmp/.tmp3xbFzH/leafslug/src/domain/restrictions.rs:7

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-check/tree/v0.22.1/src/lints/struct_missing.ron

Failed in:
  struct leafslug::domain::food::Incompatibility, previously in file /tmp/.tmp3xbFzH/leafslug/src/domain/food.rs:20
  struct leafslug::domain::food::Food, previously in file /tmp/.tmp3xbFzH/leafslug/src/domain/food.rs:7
  struct leafslug::domain::lifestyle::Lifestyle, previously in file /tmp/.tmp3xbFzH/leafslug/src/domain/lifestyle.rs:8

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-check/tree/v0.22.1/src/lints/struct_pub_field_missing.ron

Failed in:
  field sustitutes of struct Ingredient, previously in file /tmp/.tmp3xbFzH/leafslug/src/domain/ingrediants.rs:11
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/prmadev/leafslug/compare/v0.1.5...v0.2.0) - 2023-09-04

### Added
- add simple login api
- update the model for use with a product
- add figment configuration
- add quick_dev
- add axum infra
- add some crates
- remove cargo migrate
- add .sqlx dir
- add crud for ingredients

### Fixed
- returning the result directly in the quick_dev
- fix linting issues here and there
- comment the test out

### Other
- better test management
- comment out axum for now
- *(deps)* bump rustls-webpki from 0.101.3 to 0.101.4
- add comment explaining lesly
- ignore clippy::multiple_crate_versions
- remove link checker
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).